### PR TITLE
Fix dependent columns update logic

### DIFF
--- a/widget.py
+++ b/widget.py
@@ -1,70 +1,193 @@
 import pandas as pd
 import ipywidgets as widgets
 from IPython.display import display, clear_output
+from typing import Any, Dict, List
 
-class UserControlWidget:
-    def __init__(self, model, columns):
+class UserControlInputWidget:
+    """사용자 입력을 받아 예측을 수행하는 인터랙티브 위젯."""
+
+    def __init__(
+        self,
+        model: Any,
+        user_control_columns: Dict[str, Dict[str, float]],
+        reference: pd.DataFrame,
+        highlight_columns: List[str] | None = None,
+        *,
+        expansion_alpha: float = 2.0,
+        clamp_min: float | None = None,
+        clamp_max: float | None = None,
+        dependent_columns: List[str] | None = None,
+    ) -> None:
+        """위젯을 초기화한다.
+
+        Parameters
+        ----------
+        model : Any
+            ``predict`` 메서드를 가진 예측 모델
+        user_control_columns : dict
+            ``int`` 또는 ``float`` 타입별로 컬럼과 스텝을 지정하는 딕셔너리
+        reference : pandas.DataFrame
+            기본 값과 범위 계산에 사용하는 참조 데이터
+        highlight_columns : list[str], optional
+            강조 표시할 컬럼 목록
+        expansion_alpha : float, optional
+            입력 허용 범위를 ``alpha * std`` 만큼 확장할 배수 (1.0~3.0)
+        clamp_min : float, optional
+            확장 시 적용할 최소값 제한
+        clamp_max : float, optional
+            확장 시 적용할 최대값 제한
+        dependent_columns : list[str], optional
+            다른 입력에 의해 계산되는 읽기 전용 컬럼
+        """
+
         self.model = model
-        self.columns = columns
-        self.total_df = pd.DataFrame(columns=columns)
+        self.user_control_columns = user_control_columns
+        self.reference = reference
+        self.highlight_columns = highlight_columns or []
+        self.expansion_alpha = max(1.0, min(expansion_alpha, 3.0))
+        self.clamp_min = clamp_min
+        self.clamp_max = clamp_max
+        self.dependent_columns = dependent_columns or []
 
-        # User input widgets
-        self.input_widgets = {
-            '충진_하단': widgets.FloatText(description='충진_하단'),
-            '충진_중단': widgets.FloatText(description='충진_중단'),
-            '충진_상단': widgets.FloatText(description='충진_상단'),
-        }
+        # Keep columns attribute for compatibility with prediction stage
+        int_cols = list(user_control_columns.get("int", {}).keys())
+        float_cols = list(user_control_columns.get("float", {}).keys())
+        self.columns = int_cols + float_cols
+        self.total_df = pd.DataFrame(columns=self.columns)
+
+        # User input widgets generated from provided columns
+        self.widgets_dict = {}
 
         # Buttons
-        self.submit_button = widgets.Button(description='Submit', button_style='success')
-        self.predict_button = widgets.Button(description='Predict', button_style='info')
+        self.submit_button = widgets.Button(description="Submit", button_style="success")
+        self.predict_button = widgets.Button(description="Predict", button_style="info")
+        self.reset_button = widgets.Button(description="Reset", button_style="warning")
         self.submit_button.on_click(self._on_submit)
         self.predict_button.on_click(self._on_predict)
+        self.reset_button.on_click(self._on_reset)
 
         self.output = widgets.Output()
         self.df_output = widgets.Output()
+        self.delete_output = widgets.Output()
 
         self.delete_buttons = []
 
-        self._display_widgets()
+        self._build_ui()
+        self._attach_observers()
 
-    def _display_widgets(self):
-        inputs = widgets.VBox(list(self.input_widgets.values()))
-        buttons = widgets.HBox([self.submit_button, self.predict_button])
-        display(inputs, buttons, self.output, self.df_output)
+    def _build_ui(self) -> None:
+        """위젯 화면을 구성한다."""
 
-    def _calculate_dependent_columns(self, df):
-        # Modular calculation function
-        calculations = [
-            lambda df: df.assign(장입Total=df[['충진_하단', '충진_중단', '충진_상단']].sum(axis=1))
-            # More calculations can be added here
-        ]
-        for calc_func in calculations:
-            df = calc_func(df)
+        widget_list = []  # 각 입력 위젯을 차례로 담을 리스트
+        for dtype, cols in self.user_control_columns.items():
+            for col, step in cols.items():
+                series = self.reference[col] if col in self.reference else pd.Series(dtype=float)
+                mean_val = series.mean() if not series.empty else 0
+                min_val = series.min() if not series.empty else 0
+                max_val = series.max() if not series.empty else 0
+                std_val = series.std() if not series.empty else 0
+
+                expanded_min = min_val - self.expansion_alpha * std_val
+                expanded_max = max_val + self.expansion_alpha * std_val
+                if self.clamp_min is not None:
+                    expanded_min = max(expanded_min, self.clamp_min)
+                if self.clamp_max is not None:
+                    expanded_max = min(expanded_max, self.clamp_max)
+
+                label_style = 'color:blue; font-weight:bold;' if col in self.highlight_columns else ''
+                label = widgets.HTML(
+                    value=(
+                        f"<span style='{label_style}'>{col}</span> "
+                        f"(min: {min_val:.2f} ~ max: {max_val:.2f}, "
+                        f"mean: {mean_val:.2f})"
+                    ),
+                    layout=widgets.Layout(width='500px')
+                )
+
+                if dtype == 'int':
+                    input_widget = widgets.BoundedIntText(
+                        value=int(round(mean_val)),
+                        step=step,
+                        min=int(round(expanded_min)),
+                        max=int(round(expanded_max)),
+                    )
+                else:
+                    input_widget = widgets.BoundedFloatText(
+                        value=round(float(mean_val), 3),
+                        step=step,
+                        min=float(expanded_min),
+                        max=float(expanded_max),
+                    )
+
+                if col in self.dependent_columns:
+                    input_widget.disabled = True
+
+                self.widgets_dict[col] = input_widget
+                widget_list.append(widgets.HBox([label, input_widget]))
+
+        buttons = widgets.HBox([self.submit_button, self.predict_button, self.reset_button])
+        form = widgets.VBox(widget_list + [buttons, self.delete_output, self.output, self.df_output])
+        display(form)
+
+    def _attach_observers(self) -> None:
+        """입력 값이 변할 때 종속 컬럼을 갱신하도록 이벤트를 연결한다."""
+        for col, widget in self.widgets_dict.items():
+            if col not in self.dependent_columns:
+                widget.observe(self._on_input_change, names="value")
+
+        # Initial update to compute dependent columns
+        self._update_dependent_columns()
+
+    def _calculate_dependent_columns(self, df: pd.DataFrame) -> pd.DataFrame:
+        """현재 입력 값으로부터 종속 컬럼을 계산한다."""
+
+        # 예: 상단 + 중단 + 하단의 합을 총합 컬럼에 반영
+        if {'상단', '중단', '하단', '총합'}.issubset(df.columns):
+            df['총합'] = df[['상단', '중단', '하단']].sum(axis=1)
+
         return df
 
-    def _validate_input(self, df):
-        # Separate validation function
-        errors = []
-        if (df['장입Total'] != 16).any():
-            errors.append("'장입Total'은 반드시 16이어야 합니다.")
+    def _validate_input(self, df: pd.DataFrame) -> List[str]:
+        """사용자 입력이 규칙을 지키는지 확인한다."""
+
+        errors: List[str] = []
+        if '총합' in df.columns and (df['총합'] != 16).any():
+            errors.append("'총합'은 반드시 16이어야 합니다.")
         return errors
 
-    def _style_dataframe(self):
-        # DataFrame styling based on validation
+    def _style_dataframe(self) -> None:
+        """검증 결과를 반영해 데이터프레임을 꾸민다."""
+
+        # 유효성 검사를 위한 하이라이트 함수
         def highlight_invalid(val):
             return 'background-color: red' if val != 16 else ''
 
-        styled_df = self.total_df.style.applymap(
-            highlight_invalid, subset=['장입Total']
-        )
+        styled_df = self.total_df.style
+
+        # Highlight 총합 validity if present
+        if '총합' in self.total_df.columns:
+            styled_df = styled_df.applymap(highlight_invalid, subset=['총합'])
+
+        # Highlight user specified columns based on reference statistics
+        for col in self.highlight_columns:
+            if col in self.total_df.columns and col in self.reference.columns:
+                mean = self.reference[col].mean()
+                std = self.reference[col].std()
+
+                def highlight_range(val, m=mean, s=std):
+                    return 'background-color: yellow' if val < m - s or val > m + s else ''
+
+                styled_df = styled_df.applymap(highlight_range, subset=[col])
+
         with self.df_output:
             clear_output()
             display(styled_df)
 
-    def _on_submit(self, b):
-        # Gather inputs
-        input_data = {col: widget.value for col, widget in self.input_widgets.items()}
+    def _on_submit(self, b: widgets.Button) -> None:
+        """사용자가 입력한 값을 데이터프레임에 추가한다."""
+
+        # 모든 입력 값을 하나의 딕셔너리로 모은다
+        input_data = {col: widget.value for col, widget in self.widgets_dict.items()}
         input_df = pd.DataFrame([input_data], columns=self.columns)
 
         # Calculate dependent columns
@@ -76,9 +199,22 @@ class UserControlWidget:
         # Add to total DataFrame
         self.total_df = pd.concat([self.total_df, input_df], ignore_index=True)
 
-        # Add delete button
-        delete_button = widgets.Button(description=f"Delete Row {len(self.total_df)-1}", button_style='danger', layout=widgets.Layout(width='120px'))
-        delete_button.on_click(lambda btn, idx=len(self.total_df)-1: self._delete_row(idx))
+        # Add delete button for the new row
+        new_idx = len(self.total_df) - 1
+        delete_button = widgets.Button(
+            description=f"Delete Row {new_idx}",
+            button_style="danger",
+            layout=widgets.Layout(width="120px"),
+        )
+
+        # Store the index on the button so the callback always has the current
+        # value even after other rows are deleted.
+        delete_button.idx = new_idx
+
+        def handle_click(btn):
+            self._delete_row(btn.idx)
+
+        delete_button.on_click(handle_click)
         self.delete_buttons.append(delete_button)
 
         self._display_delete_buttons()
@@ -90,26 +226,59 @@ class UserControlWidget:
                 for err in errors:
                     print(f"Validation Error: {err}")
 
-    def _display_delete_buttons(self):
+    def _display_delete_buttons(self) -> None:
+        """현재 삭제 버튼들을 화면에 다시 표시한다."""
+
         buttons_box = widgets.HBox(self.delete_buttons)
-        with self.output:
+        with self.delete_output:
             clear_output()
             display(buttons_box)
 
-    def _delete_row(self, idx):
-        # Delete row from DataFrame
+    def _update_dependent_columns(self) -> None:
+        """현재 입력 값으로 종속 컬럼을 다시 계산하고 위젯에 반영한다."""
+        input_values = {c: w.value for c, w in self.widgets_dict.items()}
+        df = pd.DataFrame([input_values], columns=self.columns)
+        df = self._calculate_dependent_columns(df)
+        for col in self.dependent_columns:
+            if col in df.columns and col in self.widgets_dict:
+                val = df[col].iloc[0]
+                widget = self.widgets_dict[col]
+                widget.value = val
+                # 종속 컬럼 값을 해당 위젯에 반영한다
+
+    def _on_input_change(self, change: dict) -> None:
+        """입력 값 변경 시 호출되어 종속 컬럼을 갱신한다."""
+
+        self._update_dependent_columns()
+
+    def _on_reset(self, b: widgets.Button) -> None:
+        """모든 입력 결과를 초기 상태로 되돌린다."""
+        self.total_df = pd.DataFrame(columns=self.columns)
+        self.delete_buttons = []
+        self._display_delete_buttons()
+        self._style_dataframe()
+
+    def _delete_row(self, idx: int) -> None:
+        """지정한 행을 삭제하고 버튼 상태를 갱신한다."""
+
+        # 범위를 벗어나면 아무 것도 하지 않음
+        if idx >= len(self.total_df):
+            return
+
         self.total_df = self.total_df.drop(index=idx).reset_index(drop=True)
         del self.delete_buttons[idx]
 
-        # Reset button labels and handlers
+        # Reset button labels and stored indices without reattaching handlers
         for i, btn in enumerate(self.delete_buttons):
             btn.description = f"Delete Row {i}"
-            btn.on_click(lambda btn, idx=i: self._delete_row(idx))
+            btn.idx = i
 
         self._display_delete_buttons()
         self._style_dataframe()
 
-    def _on_predict(self, b):
+    def _on_predict(self, b: widgets.Button) -> None:
+        """모은 데이터를 사용하여 모델 예측을 실행한다."""
+
         with self.output:
             clear_output()
             if self.total_df.empty:
@@ -124,14 +293,23 @@ class UserControlWidget:
                     print(f"- {err}")
                 return
 
-            predictions = self.model.predict(self.total_df[self.columns])
+            feature_cols = [c for c in self.total_df.columns if c != 'Prediction']
+            predictions = self.model.predict(self.total_df[feature_cols])
             result_df = self.total_df.copy()
             result_df['Prediction'] = predictions
 
             print("예측 결과:")
             display(result_df)
 
-# Example usage (Replace with actual model)
+# Example usage (Replace with actual model and reference data)
 # xgb_model = trained_xgb_model
-data_columns = ['충진_하단', '충진_중단', '충진_상단', '장입Total']
-# widget = UserControlWidget(model=xgb_model, columns=data_columns)
+# reference_df = pd.read_csv('training_data.csv')
+# control_columns = {
+#     'int': {'하단': 1, '중단': 1, '상단': 1, '총합': 1},
+# }
+# widget = UserControlInputWidget(
+#     model=xgb_model,
+#     user_control_columns=control_columns,
+#     reference=reference_df,
+#     highlight_columns=list(control_columns.get('int', {}).keys()),
+# )


### PR DESCRIPTION
## Summary
- compute dependent columns directly without adding new ones
- validate and highlight `총합` instead of `장입Total`
- update example usage with new column names
- remove color indicators when updating dependent columns

## Testing
- `python -m py_compile widget.py`


------
https://chatgpt.com/codex/tasks/task_e_684bdbe59de48330831c9b3c1c3ef9db